### PR TITLE
Refresh and Access Token expiration update

### DIFF
--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -3,8 +3,8 @@ package auth
 import "time"
 
 const (
-	refreshTokenTimeLimit    = 60
-	accessTokenTimeLimit     = 10 * time.Second // change me to something quicker
+	refreshTokenTimeLimit    = 240
+	accessTokenTimeLimit     = 30 * time.Second
 	RefreshTokenCleanerRate  = 30 * time.Second
 	ImminentExpirationWindow = int64(float64(refreshTokenTimeLimit) * .2) // TODO make better?
 


### PR DESCRIPTION
Setting the expiration for a refresh token to 2 minutes. Setting the expiration for an access token to 30 seconds. Still in testing mode so this should be moved up again in the future.
