### PR TITLE
Refresh Token Patch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -33,11 +33,12 @@ func NewApp(cfg cfg.Config, authService auth.AuthService, userService user.UserS
 // TODO make this entire file better
 func (wb *app) BackgroundCleaner(authCleaner auth.AuthCleaner) {
 	const refreshTokenTimeLimit = 60
-	go func() {
-		for range wb.timer.Tick(auth.RefreshTokenCleanerRate) {
-			_ = authCleaner.CleanupExpiredRefreshTokens(wb.timer.Now().Unix() - refreshTokenTimeLimit)
-		}
-	}()
+	return // fixme
+	// go func() {
+	// 	for range wb.timer.Tick(auth.RefreshTokenCleanerRate) {
+	// 		_ = authCleaner.CleanupExpiredRefreshTokens(wb.timer.Now().Unix() - refreshTokenTimeLimit)
+	// 	}
+	// }()
 }
 
 func (wb *app) errorResponse(err error, w http.ResponseWriter) {

--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -3,7 +3,7 @@ package auth
 import "time"
 
 const (
-	refreshTokenTimeLimit    = 240
+	refreshTokenTimeLimit    = 36000 // 10 minutes
 	accessTokenTimeLimit     = 30 * time.Second
 	RefreshTokenCleanerRate  = 30 * time.Second
 	ImminentExpirationWindow = int64(float64(refreshTokenTimeLimit) * .2) // TODO make better?


### PR DESCRIPTION
Currently refresh tokens are getting removed prematurely from the database. This patch removes the cleaner for the time being.
